### PR TITLE
fix: keep MCP stdio diagnostics off stdout

### DIFF
--- a/src/config/config-validator.ts
+++ b/src/config/config-validator.ts
@@ -35,7 +35,7 @@ export class ConfigurationValidator {
     const errors: ValidationError[] = [];
     const warnings: ConfigurationWarning[] = [];
 
-    console.log('🔍 Validating BCKB configuration...');
+    console.error('🔍 Validating BCKB configuration...');
 
     // 1. Basic structure validation
     this.validateBasicStructure(config, errors);
@@ -65,8 +65,8 @@ export class ConfigurationValidator {
       score
     };
 
-    console.log(`${result.valid ? '✅' : '❌'} Configuration validation complete`);
-    console.log(`   Errors: ${errors.length}, Warnings: ${warnings.length}, Score: ${score}/100`);
+    console.error(`${result.valid ? '✅' : '❌'} Configuration validation complete`);
+    console.error(`   Errors: ${errors.length}, Warnings: ${warnings.length}, Score: ${score}/100`);
 
     return result;
   }

--- a/src/services/code-analysis-service.ts
+++ b/src/services/code-analysis-service.ts
@@ -113,7 +113,7 @@ export class CodeAnalysisService {
   private async loadPatterns(): Promise<ALCodePattern[]> {
     // Check cache first
     if (this.patternCache && Date.now() < this.cacheExpiry) {
-      console.log(
+      console.error(
         `🔍 Using cached patterns: ${this.patternCache.length} patterns`,
       );
       return this.patternCache;
@@ -123,7 +123,7 @@ export class CodeAnalysisService {
       // Get all code-pattern topics from the knowledge base
       const patternTopics =
         await this.knowledgeService.findTopicsByType("code-pattern");
-      console.log(
+      console.error(
         `🔍 Found ${patternTopics.length} code-pattern topics in knowledge base`,
       );
 
@@ -150,7 +150,7 @@ export class CodeAnalysisService {
       // This ensures we always have analysis capabilities
       const basePatterns =
         patterns.length > 0 ? patterns : this.getFallbackPatterns();
-      console.log(
+      console.error(
         `🔍 Using ${basePatterns.length} base patterns (${patterns.length > 0 ? "from knowledge base" : "fallback"})`,
       );
 
@@ -158,7 +158,7 @@ export class CodeAnalysisService {
       this.patternCache = [...basePatterns, ...orgStandards];
       this.cacheExpiry = Date.now() + this.CACHE_TTL;
 
-      console.log(
+      console.error(
         `🔍 Total patterns loaded: ${this.patternCache.length} (${basePatterns.length} base + ${orgStandards.length} org standards)`,
       );
 
@@ -194,7 +194,7 @@ export class CodeAnalysisService {
         standards.push(...guidelines);
       }
 
-      console.log(
+      console.error(
         `📋 Loaded ${standards.length} organization standards from knowledge layers (company + project)`,
       );
       return standards;
@@ -1101,7 +1101,7 @@ export class CodeAnalysisService {
         }
       }
 
-      console.log(
+      console.error(
         `✅ Checked ${companyStandards.length} organization standards (company + project), found ${violations.length} relevant guidelines`,
       );
     } catch (error) {
@@ -1283,7 +1283,7 @@ export class CodeAnalysisService {
             id.includes("/code-analysis/suggestions/"),
         );
 
-        console.log(
+        console.error(
           `🔍 Found ${suggestionTopicIds.length} code analysis suggestion topics in layers`,
         );
 
@@ -1307,14 +1307,14 @@ export class CodeAnalysisService {
               const suggestionText = this.extractSuggestionText(topic.content);
 
               suggestions.set(suggestionId, suggestionText);
-              console.log(
+              console.error(
                 `  ✓ Loaded suggestion: ${suggestionId} from layer ${resolution.sourceLayer}`,
               );
             }
           }
         }
 
-        console.log(
+        console.error(
           `📋 Loaded ${suggestions.size} code analysis suggestions from layers`,
         );
       }

--- a/src/tools/analyze_al_code/handler.ts
+++ b/src/tools/analyze_al_code/handler.ts
@@ -65,7 +65,7 @@ export function createAnalyzeAlCodeHandler(services: any) {
     if (workspace_path) {
       // Scan workspace for .al files
       const alFiles = findAlFiles(workspace_path);
-      console.log(`📁 Found ${alFiles.length} .al files in workspace: ${workspace_path}`);
+      console.error(`📁 Found ${alFiles.length} .al files in workspace: ${workspace_path}`);
 
       for (const filePath of alFiles) {
         const content = readFileContent(filePath);

--- a/tests/integration/mcp-stdio-clean.test.ts
+++ b/tests/integration/mcp-stdio-clean.test.ts
@@ -1,0 +1,153 @@
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+
+interface JsonRpcMessage {
+  id?: number;
+  result?: any;
+  error?: any;
+}
+
+interface StdioProbe {
+  callTool(name: string, args: Record<string, unknown>): Promise<JsonRpcMessage>;
+  close(): void;
+  anomalies: string[];
+}
+
+async function createStdioProbe(): Promise<StdioProbe> {
+  const serverPath = resolve(process.cwd(), 'dist/index.js');
+
+  if (!existsSync(serverPath)) {
+    throw new Error('dist/index.js not found. Run npm run build before integration tests.');
+  }
+
+  const child = spawn(process.execPath, [serverPath], {
+    cwd: process.cwd(),
+    env: { ...process.env, MCP_SERVER_MODE: 'stdio' },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  return initializeProbe(child);
+}
+
+async function initializeProbe(child: ChildProcessWithoutNullStreams): Promise<StdioProbe> {
+  let stdoutBuffer = '';
+  let nextId = 1;
+  const anomalies: string[] = [];
+  const messages: JsonRpcMessage[] = [];
+
+  child.stdout.on('data', (chunk) => {
+    stdoutBuffer += chunk.toString('utf8');
+
+    let newlineIndex = stdoutBuffer.indexOf('\n');
+    while (newlineIndex >= 0) {
+      const line = stdoutBuffer.slice(0, newlineIndex).replace(/\r$/, '');
+      stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
+
+      if (line.length > 0) {
+        try {
+          messages.push(JSON.parse(line));
+        } catch {
+          anomalies.push(line);
+        }
+      }
+
+      newlineIndex = stdoutBuffer.indexOf('\n');
+    }
+  });
+
+  const send = (method: string, params: Record<string, unknown>): number => {
+    const id = nextId++;
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    return id;
+  };
+
+  const notify = (method: string, params: Record<string, unknown>): void => {
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n');
+  };
+
+  const waitFor = (id: number, timeoutMs = 30000): Promise<JsonRpcMessage> =>
+    new Promise((resolveMessage, reject) => {
+      const startedAt = Date.now();
+      const interval = setInterval(() => {
+        const message = messages.find((item) => item.id === id);
+        if (message) {
+          clearInterval(interval);
+          resolveMessage(message);
+          return;
+        }
+
+        if (Date.now() - startedAt > timeoutMs) {
+          clearInterval(interval);
+          reject(new Error(`Timed out waiting for JSON-RPC response ${id}`));
+        }
+      }, 25);
+    });
+
+  const initializeId = send('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'stdio-cleanliness-test', version: '1.0.0' },
+  });
+
+  await waitFor(initializeId);
+  notify('notifications/initialized', {});
+
+  return {
+    anomalies,
+    callTool: async (name: string, args: Record<string, unknown>): Promise<JsonRpcMessage> => {
+      const id = send('tools/call', { name, arguments: args });
+      return waitFor(id);
+    },
+    close: (): void => {
+      child.kill();
+    },
+  };
+}
+
+describe('MCP stdio transport cleanliness', () => {
+  it('keeps diagnostic logging off stdout during code analysis tool calls', async () => {
+    const probe = await createStdioProbe();
+
+    try {
+      const setWorkspace = await probe.callTool('set_workspace_info', {
+        workspace_root: process.cwd(),
+        available_mcps: [],
+      });
+      expect(setWorkspace.error).toBeUndefined();
+
+      const askExpert = await probe.callTool('ask_bc_expert', {
+        preferred_specialist: 'performance-expert',
+        question: 'Is this AL loop performance-safe?',
+        context: [
+          'codeunit 50100 Test',
+          '{',
+          '    procedure Run()',
+          '    var',
+          '        SalesLine: Record "Sales Line";',
+          '    begin',
+          '        SalesLine.SetRange("Document Type", SalesLine."Document Type"::Order);',
+          '        SalesLine.SetLoadFields("Document No.", "Line No.", Amount);',
+          '        if SalesLine.FindSet() then',
+          '            repeat',
+          '                if SalesLine.Amount > 0 then',
+          '                    Message(\'%1\', SalesLine."Document No.");',
+          '            until SalesLine.Next() = 0;',
+          '    end;',
+          '}',
+        ].join('\n'),
+      });
+      expect(askExpert.error).toBeUndefined();
+
+      const analyzeWorkspace = await probe.callTool('analyze_al_code', {
+        workspace_path: process.cwd(),
+      });
+      expect(analyzeWorkspace.error).toBeUndefined();
+
+      expect(probe.anomalies).toEqual([]);
+    } finally {
+      probe.close();
+    }
+  }, 45000);
+});

--- a/tests/unit/mcp-stdio-logging.test.ts
+++ b/tests/unit/mcp-stdio-logging.test.ts
@@ -1,0 +1,58 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const SERVER_SOURCE_DIRS = [
+  'src/config',
+  'src/index.ts',
+  'src/layers',
+  'src/sdk',
+  'src/services',
+  'src/tools',
+];
+
+const STDOUT_PATTERNS = [
+  /\bconsole\.log\s*\(/,
+  /\bconsole\.info\s*\(/,
+  /\bconsole\.debug\s*\(/,
+  /\bprocess\.stdout\s*\./,
+  /\bstdout\.write\s*\(/,
+];
+
+function collectTypeScriptFiles(path: string): string[] {
+  const fullPath = join(process.cwd(), path);
+  const stats = statSync(fullPath);
+
+  if (stats.isFile()) {
+    return path.endsWith('.ts') ? [fullPath] : [];
+  }
+
+  return readdirSync(fullPath).flatMap((entry) => {
+    const childPath = join(fullPath, entry);
+    const childStats = statSync(childPath);
+
+    if (childStats.isDirectory()) {
+      return collectTypeScriptFiles(relative(process.cwd(), childPath));
+    }
+
+    return childPath.endsWith('.ts') ? [childPath] : [];
+  });
+}
+
+describe('MCP stdio logging safety', () => {
+  it('does not write diagnostics to stdout from server code', () => {
+    const violations = SERVER_SOURCE_DIRS
+      .flatMap(collectTypeScriptFiles)
+      .flatMap((filePath) => {
+        const source = readFileSync(filePath, 'utf8');
+
+        return source
+          .split(/\r?\n/)
+          .map((line, index) => ({ line, lineNumber: index + 1 }))
+          .filter(({ line }) => STDOUT_PATTERNS.some((pattern) => pattern.test(line)))
+          .map(({ line, lineNumber }) => `${relative(process.cwd(), filePath)}:${lineNumber}: ${line.trim()}`);
+      });
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #42.

MCP stdio servers must keep stdout reserved for JSON-RPC protocol messages. This PR moves remaining server-side diagnostic output from stdout to stderr in code paths that can run while serving MCP requests.

Changed runtime logging in:

- `src/services/code-analysis-service.ts`
- `src/tools/analyze_al_code/handler.ts`
- `src/config/config-validator.ts`

`src/cli.ts` is intentionally left unchanged because CLI output belongs on stdout.

## Why

A strict MCP stdio client can close the transport when diagnostics are emitted on stdout. In Codex this surfaced during `ask_bc_expert` with AL context as:

```text
rmcp::transport::async_rw: Error reading from stream: serde error expected value at line 1 column 1
tool call error: tool call failed for bc-knowledge/ask_bc_expert
Caused by: Transport closed
```

A raw stdio probe showed diagnostic lines such as `Found 0 code-pattern topics in knowledge base` being emitted on stdout during the tool call. Redirecting those diagnostics to stderr keeps stdout protocol-clean.

## Tests

- `npm run build`
- `npm run test:contracts`
- `npm run test:unit`
- `npm run test:integration`
- `npx vitest run --config vitest.unit.config.ts tests/unit/mcp-stdio-logging.test.ts`
- `npx vitest run --config vitest.integration.config.ts tests/integration/mcp-stdio-clean.test.ts`

## Regression coverage

Adds two guards:

- `tests/integration/mcp-stdio-clean.test.ts`: spawns `dist/index.js`, performs real MCP JSON-RPC calls, and fails if stdout contains non-JSON diagnostic lines.
- `tests/unit/mcp-stdio-logging.test.ts`: static guard preventing `console.log`, `console.info`, `console.debug`, or direct stdout writes from server-side source paths, excluding CLI code.