### PR TITLE
Auto-initialize workspace from BC_INTEL_WORKSPACE_PATH env var

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1068,6 +1068,48 @@ ${enhancedResult.routingOptions.map((option) => `- ${option.replace("🎯 Start 
     return insights;
   }
 
+  /**
+   * Auto-initialize the workspace from the BC_INTEL_WORKSPACE_PATH environment
+   * variable, when provided by the host (e.g. the VS Code extension).
+   *
+   * Without this, the only way to set the workspace is for the client to call
+   * set_workspace_info with an explicit path. Some clients cannot reliably
+   * determine that path and end up passing a placeholder, which fails and loops.
+   * Reading the host-provided path here makes initialization deterministic and
+   * is a no-op when the variable is absent or points to a missing directory.
+   */
+  private async autoInitializeWorkspaceFromEnvironment(): Promise<void> {
+    const envPath = process.env["BC_INTEL_WORKSPACE_PATH"];
+    if (!envPath) {
+      return;
+    }
+
+    try {
+      const { existsSync } = await import("fs");
+      if (!existsSync(envPath)) {
+        console.error(
+          `⚠️ BC_INTEL_WORKSPACE_PATH is set but does not exist: ${envPath}`,
+        );
+        return;
+      }
+
+      console.error(
+        `📁 Auto-initializing workspace from BC_INTEL_WORKSPACE_PATH: ${envPath}`,
+      );
+      const result = await this.setWorkspaceInfo(envPath, this.availableMcps);
+      console.error(
+        result.success
+          ? `✅ ${result.message}`
+          : `⚠️ Auto-initialization failed: ${result.message}`,
+      );
+    } catch (error) {
+      console.error(
+        "⚠️ Failed to auto-initialize workspace from environment:",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
   async run(): Promise<void> {
     try {
       // Ultra-early diagnostics for platform issues
@@ -1096,6 +1138,12 @@ ${enhancedResult.routingOptions.map((option) => `- ${option.replace("🎯 Start 
       // 1. If client calls set_workspace_info, that triggers initialization
       // 2. If client calls a tool directly, the tool waits and triggers initialization
       console.error("💡 Server ready. Services will initialize on first request or set_workspace_info call.");
+
+      // If the host (e.g. the VS Code extension) provided a workspace path via
+      // the BC_INTEL_WORKSPACE_PATH environment variable, initialize from it now.
+      // This breaks the chicken-and-egg loop where a client calls get_workspace_info
+      // (empty) and then guesses a placeholder path for set_workspace_info.
+      await this.autoInitializeWorkspaceFromEnvironment();
 
       // Server is ready to accept requests immediately
       // Tools will trigger initialization on first use if needed

--- a/src/tools/set_workspace_info/handler.ts
+++ b/src/tools/set_workspace_info/handler.ts
@@ -13,8 +13,11 @@ export interface SetWorkspaceInfoContext {
 export function createSetWorkspaceInfoHandler(services: any) {
   const context = services as SetWorkspaceInfoContext;
 
-  return async (args: { workspace_root: string; available_mcps?: string[] }) => {
-    const { workspace_root, available_mcps } = args;
+  return async (args: { workspace_root?: string; workspace_path?: string; available_mcps?: string[] }) => {
+    // Accept `workspace_path` as a backward-compatible alias for `workspace_root`.
+    // `workspace_root` takes precedence when both are supplied.
+    const workspace_root = args.workspace_root ?? args.workspace_path;
+    const { available_mcps } = args;
 
     if (!workspace_root) {
       return {

--- a/src/tools/set_workspace_info/schema.ts
+++ b/src/tools/set_workspace_info/schema.ts
@@ -16,6 +16,10 @@ export const setWorkspaceInfoTool: Tool = {
         type: 'string',
         description: 'Absolute path to the workspace/project root directory (e.g., C:/projects/my-bc-app or /home/user/projects/my-bc-app)'
       },
+      workspace_path: {
+        type: 'string',
+        description: 'Alias for workspace_root. Accepted for backward compatibility; if both are provided, workspace_root takes precedence.'
+      },
       available_mcps: {
         type: 'array',
         items: { type: 'string' },

--- a/tests/tools/workspace-tools.test.ts
+++ b/tests/tools/workspace-tools.test.ts
@@ -218,6 +218,66 @@ describe('Workspace Management Tools', () => {
       expect(setWorkspaceInfoSpy).not.toHaveBeenCalled();
     });
 
+    it('should accept workspace_path as an alias for workspace_root', async () => {
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'set_workspace_info',
+          arguments: {
+            workspace_path: 'C:/projects/my-bc-app',
+            available_mcps: []
+          }
+        }
+      };
+
+      const result = await setWorkspaceInfoHandler(request.params.arguments);
+      const response = JSON.parse(result.content[0].text);
+
+      expect(response.success).toBe(true);
+      expect(response.workspace_root).toBe('C:/projects/my-bc-app');
+      expect(setWorkspaceInfoSpy).toHaveBeenCalledWith('C:/projects/my-bc-app', []);
+    });
+
+    it('should prefer workspace_root when both workspace_root and workspace_path are provided', async () => {
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'set_workspace_info',
+          arguments: {
+            workspace_root: 'C:/projects/primary',
+            workspace_path: 'C:/projects/alias',
+            available_mcps: []
+          }
+        }
+      };
+
+      const result = await setWorkspaceInfoHandler(request.params.arguments);
+      const response = JSON.parse(result.content[0].text);
+
+      expect(response.success).toBe(true);
+      expect(response.workspace_root).toBe('C:/projects/primary');
+      expect(setWorkspaceInfoSpy).toHaveBeenCalledWith('C:/projects/primary', []);
+    });
+
+    it('should still require a path when neither workspace_root nor workspace_path is provided', async () => {
+      const request: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'set_workspace_info',
+          arguments: {
+            available_mcps: []
+          }
+        }
+      };
+
+      const result = await setWorkspaceInfoHandler(request.params.arguments);
+      const response = JSON.parse(result.content[0].text);
+
+      expect(response.success).toBe(false);
+      expect(response.error).toBe('workspace_root is required');
+      expect(setWorkspaceInfoSpy).not.toHaveBeenCalled();
+    });
+
     it('should trigger layer reload when configured', async () => {
       setWorkspaceInfoSpy.mockResolvedValue({
         success: true,
@@ -370,6 +430,7 @@ describe('Workspace Management Tools', () => {
       expect(setWorkspaceInfoTool.name).toBe('set_workspace_info');
       expect(setWorkspaceInfoTool.description).toContain('workspace root');
       expect(setWorkspaceInfoTool.inputSchema.properties.workspace_root).toBeDefined();
+      expect(setWorkspaceInfoTool.inputSchema.properties.workspace_path).toBeDefined();
       expect(setWorkspaceInfoTool.inputSchema.properties.available_mcps).toBeDefined();
       expect(setWorkspaceInfoTool.inputSchema.required).toContain('workspace_root');
     });


### PR DESCRIPTION
## Why this pull request

When the server is launched by a host that already knows the workspace path
(for example the VS Code extension, which passes it via the
`BC_INTEL_WORKSPACE_PATH` environment variable), the server never reads that
value. The workspace therefore stays uninitialized until a client explicitly
calls `set_workspace_info` with an absolute path.

## The scenario that produced the error

1. A specialist chat participant starts and calls `get_workspace_info`.
2. The workspace is null, so the participant tries to set it by calling
   `set_workspace_info`.
3. The client cannot reliably determine the absolute workspace path, so it
   passes a placeholder such as `/path/to/your/workspace`.
4. That path does not exist, the call fails, and the participant retries,
   producing a loop where the workspace is never set and the user is repeatedly
   asked to provide a path.

## What this changes

- The server now auto-initializes the workspace from `BC_INTEL_WORKSPACE_PATH`
  at startup when the variable is present and points to an existing directory.
  This is a no-op when the variable is absent or invalid, so existing behavior
  is unchanged.
- `set_workspace_info` also accepts `workspace_path` as a backward-compatible
  alias for `workspace_root`. `workspace_root` still takes precedence when both
  are supplied, and it remains required when neither is given.

## Tests

Added unit tests covering the `workspace_path` alias, precedence of
`workspace_root`, and the unchanged required-path behavior. The existing test
suite continues to pass.
